### PR TITLE
Add visual change toolbar for website editing mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/styles.css" />
+      <script src="/script.js" defer></script>
   </head>
   <body>
     <header class="site-header">

--- a/public/script.js
+++ b/public/script.js
@@ -1,1 +1,61 @@
-// Real estate landing page - no interactive scripts needed yet
+(function(){
+  function isEditMode(){
+    try {
+      const params = new URLSearchParams(window.location.search || '');
+      return params.has('edit') || sessionStorage.getItem('edit-mode') === '1';
+    } catch (_) { return false; }
+  }
+
+  function injectStyles(){
+    if (document.getElementById('visual-change-styles')) return;
+    const css = `
+      .visual-change-toolbar{position:fixed;top:96px;right:16px;z-index:1000;pointer-events:auto}
+      .visual-change-button{display:inline-flex;align-items:center;justify-content:center;padding:9px 16px;background:var(--button-bg);color:var(--button-text);border-radius:9999px;border:1px solid rgba(0,0,0,0.08);font-family:'Inter',sans-serif;font-size:14px;font-weight:500;cursor:pointer;box-shadow:0 4px 12px rgba(0,0,0,0.06);transition:transform .2s ease, box-shadow .2s ease}
+      .visual-change-button:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(0,0,0,0.08)}
+      body.visual-change-on :where(h1,h2,h3,h4,h5,h6,p,a,section,div,article,figure,img,button){outline:1px dashed rgba(7,24,57,.6);outline-offset:2px;cursor:crosshair}
+    `;
+    const style = document.createElement('style');
+    style.id = 'visual-change-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  function createToolbar(){
+    const toolbar = document.createElement('div');
+    toolbar.className = 'visual-change-toolbar';
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'visual-change-button';
+    btn.setAttribute('aria-label', 'Visual changes');
+    btn.textContent = 'Visual changes';
+
+    btn.addEventListener('click', () => {
+      document.body.classList.toggle('visual-change-on');
+      const on = document.body.classList.contains('visual-change-on');
+      sessionStorage.setItem('visual-change-active', on ? '1' : '0');
+    });
+
+    toolbar.appendChild(btn);
+    document.body.appendChild(toolbar);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const wasActive = sessionStorage.getItem('visual-change-active') === '1';
+    if (!isEditMode() && !wasActive) return;
+
+    injectStyles();
+    createToolbar();
+
+    if (wasActive) document.body.classList.add('visual-change-on');
+
+    window.addEventListener('keydown', (e) => {
+      if ((e.key === 'e' || e.key === 'E') && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        document.body.classList.toggle('visual-change-on');
+        const on = document.body.classList.contains('visual-change-on');
+        sessionStorage.setItem('visual-change-active', on ? '1' : '0');
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## Purpose

The user reported that the visual change option was not showing while editing the website. This PR addresses that issue by implementing a visual editing toolbar that allows users to toggle visual change mode when editing the website.

## Code changes

- **Added script inclusion**: Added `<script src="/script.js" defer></script>` to `public/index.html` to load the visual editing functionality
- **Implemented visual change toolbar**: Created a comprehensive JavaScript solution in `public/script.js` that includes:
  - Edit mode detection via URL parameters or session storage
  - Dynamic CSS injection for visual change styles
  - Floating toolbar with "Visual changes" button positioned at top-right
  - Element highlighting with dashed outlines when visual change mode is active
  - Keyboard shortcut support (Ctrl/Cmd + E) to toggle visual changes
  - Session persistence to remember visual change state
  - Hover effects and smooth transitions for better UX

The toolbar appears when in edit mode and provides an intuitive way to toggle visual editing capabilities on and off.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3e13ae05f10c4410a6207c3d2ee55fd6/flare-realm)

👀 [Preview Link](https://3e13ae05f10c4410a6207c3d2ee55fd6-flare-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3e13ae05f10c4410a6207c3d2ee55fd6</projectId>-->
<!--<branchName>flare-realm</branchName>-->