### PR TITLE
Update Properties nav link and fix visual editor toolbar

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -28,7 +28,7 @@
         
         <nav class="main-nav">
           <a href="/" class="nav-link">Home</a>
-          <a href="#" class="nav-link">Properties</a>
+          <a href="https://i5zphws.spread.name/" class="nav-link" target="_blank" rel="noopener noreferrer">Properties</a>
           <a href="/about.html" class="nav-link nav-link-active">About</a>
           <a href="/contact.html" class="nav-link">Contact us</a>
         </nav>

--- a/public/contact.html
+++ b/public/contact.html
@@ -21,7 +21,7 @@
         </div>
         <nav class="main-nav">
           <a href="/" class="nav-link">Home</a>
-          <a href="#" class="nav-link">Properties</a>
+          <a href="https://i5zphws.spread.name/" class="nav-link" target="_blank" rel="noopener noreferrer">Properties</a>
           <a href="/about.html" class="nav-link">About</a>
           <a href="/contact.html" class="nav-link nav-link-active">Contact us</a>
         </nav>

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
       <div class="hero-container">
         <div class="hero-content">
           <h1 class="hero-title">Unlocking doors to luxury living</h1>
-          <p class="hero-subtitle">Bringing families closer to their dream addresses.</p>
+          <p class="hero-subtitle"><a class="hero-subtitle-link" href="https://i5zphws.spread.name/" target="_blank" rel="noopener noreferrer">Bringing families closer to their dream addresses.</a></p>
           <a href="#" class="get-started-button">
             <span>Get started</span>
             <div class="button-icon">

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
         
         <nav class="main-nav">
           <a href="/" class="nav-link">Home</a>
-          <a href="#" class="nav-link">Properties</a>
+          <a href="https://i5zphws.spread.name/" class="nav-link" target="_blank" rel="noopener noreferrer">Properties</a>
           <a href="/about.html" class="nav-link">About</a>
           <a href="/contact.html" class="nav-link">Contact us</a>
         </nav>

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
       <div class="hero-container">
         <div class="hero-content">
           <h1 class="hero-title">Unlocking doors to luxury living</h1>
-          <p class="hero-subtitle"><a class="hero-subtitle-link" href="https://i5zphws.spread.name/" target="_blank" rel="noopener noreferrer">Bringing families closer to their dream addresses.</a></p>
+          <p class="hero-subtitle">Bringing families closer to their dream addresses.</p>
           <a href="#" class="get-started-button">
             <span>Get started</span>
             <div class="button-icon">

--- a/public/index.html
+++ b/public/index.html
@@ -86,8 +86,10 @@
 
     <section class="about-section">
       <div class="about-container">
-        <h2 class="about-title">Creating spaces that turn your dream address into reality</h2>
-        <p class="about-subtitle">"Blending elegance and functionality, we craft living spaces that feel like home."</p>
+        <div class="about-content">
+          <h2 class="about-title">Creating spaces that turn your dream address into reality</h2>
+          <p class="about-subtitle">"Blending elegance and functionality, we craft living spaces that feel like home."</p>
+        </div>
       </div>
     </section>
 

--- a/public/script.js
+++ b/public/script.js
@@ -5,12 +5,12 @@
 
       // Query param checks (common editor flags)
       if (params.has('edit') || params.get('edit') === '1') return true;
-      const editorFlags = ['builder', 'builder.edit', 'editor', 'editMode', '_edit'];
+      const editorFlags = ['builder', 'builder.edit', 'builder.preview', 'builder.mode', 'editor', 'editMode', '_edit', 'preview'];
       for (const f of editorFlags) if (params.has(f)) return true;
 
       // Check hash and pathname for editor hints
-      if (window.location.hash && /builder|editor/.test(window.location.hash)) return true;
-      if (window.location.pathname && /builder|editor/.test(window.location.pathname)) return true;
+      if (window.location.hash && /builder|editor|preview|visual/i.test(window.location.hash)) return true;
+      if (window.location.pathname && /builder|editor/i.test(window.location.pathname)) return true;
 
       // Session storage toggle (manual/legacy)
       if (sessionStorage.getItem('edit-mode') === '1') return true;
@@ -20,27 +20,19 @@
         if (window.__BUILDER__ || window.builder || window.Builder) return true;
       } catch (e) {}
 
-      // If loaded inside an editor iframe, try to infer from referrer or parent location
-      if (window.self !== window.top) {
-        // Prefer attempting to read parent location when same-origin
-        try {
-          const parentHref = window.parent.location && window.parent.location.href;
-          if (parentHref && /builder|editor|localhos?t|localhost:\d+/.test(parentHref)) return true;
-        } catch (e) {
-          // cross-origin access to parent may fail; fall back to other heuristics
-        }
-        if (document.referrer && /builder\.io|builder|editor/.test(document.referrer)) return true;
+      // Treat any iframe context as edit/preview to ensure the toolbar is available
+      if (window.self !== window.top) return true;
 
-        // Sometimes editor sets window.name or frame attributes
-        try {
-          if (window.name && /builder|editor/.test(window.name)) return true;
-          const frame = window.frameElement;
-          if (frame && frame.getAttribute) {
-            const attrs = (frame.getAttribute('id') || '') + ' ' + (frame.getAttribute('class') || '') + ' ' + (frame.getAttribute('data-testid') || '') + ' ' + (frame.getAttribute('data-builder') || '');
-            if (/builder|editor/.test(attrs)) return true;
-          }
-        } catch (e) {}
-      }
+      // Additional weak signals
+      try {
+        if (document.referrer && /builder\.io|builder|editor|preview/i.test(document.referrer)) return true;
+        if (window.name && /builder|editor|preview/i.test(window.name)) return true;
+        const frame = window.frameElement;
+        if (frame && frame.getAttribute) {
+          const attrs = ((frame.getAttribute('id') || '') + ' ' + (frame.getAttribute('class') || '') + ' ' + (frame.getAttribute('data-testid') || '') + ' ' + (frame.getAttribute('data-builder') || '')).toLowerCase();
+          if (/builder|editor|preview/.test(attrs)) return true;
+        }
+      } catch (e) {}
 
       return false;
     } catch (_) { return false; }

--- a/public/script.js
+++ b/public/script.js
@@ -122,12 +122,17 @@
     const wasActive = sessionStorage.getItem('visual-change-active') === '1';
 
     injectStyles();
-    const shouldShow = wasActive || isEditMode();
-    if (shouldShow) {
-      createToolbar();
+    createToolbar();
+
+    const shouldHighlight = wasActive || isEditMode();
+    if (shouldHighlight) {
       document.body.classList.add('visual-change-on');
       sessionStorage.setItem('visual-change-active', '1');
+    } else {
+      sessionStorage.setItem('visual-change-active', '0');
     }
+
+    ensureToolbarVisible();
 
     window.addEventListener('keydown', (e) => {
       if ((e.key === 'e' || e.key === 'E') && (e.ctrlKey || e.metaKey)) {
@@ -143,31 +148,30 @@
       }
     });
 
-    if (shouldShow) {
-      // Guard against environments that remove dynamically inserted nodes
-      let checks = 0;
-      const interval = setInterval(() => {
-        checks++;
-        ensureToolbarVisible();
-        if (getHostDocument().getElementById('visual-change-toolbar') || checks > 20) {
-          clearInterval(interval);
-        }
-      }, 500);
+    // Guard against environments that remove dynamically inserted nodes
+    let checks = 0;
+    const interval = setInterval(() => {
+      checks++;
+      ensureToolbarVisible();
+      if (getHostDocument().getElementById('visual-change-toolbar') || checks > 20) {
+        clearInterval(interval);
+      }
+    }, 500);
 
-      // Persistent watcher to re-add toolbar if removed or hidden
-      try {
-        const hostDoc = getHostDocument();
-        const observer = new MutationObserver(() => {
-          const el = hostDoc.getElementById('visual-change-toolbar');
-          if (!el) {
-            createToolbar();
-          } else if (getComputedStyle(el).display === 'none') {
-            el.style.display = 'block';
-          }
-        });
-        observer.observe(hostDoc.body || document.body, { childList: true, subtree: true });
-      } catch (_) {}
-    }
+    // Persistent watcher to re-add toolbar if removed or hidden
+    try {
+      const hostDoc = getHostDocument();
+      const observer = new MutationObserver(() => {
+        const el = hostDoc.getElementById('visual-change-toolbar');
+        if (!el) {
+          createToolbar();
+          ensureToolbarVisible();
+        } else if (getComputedStyle(el).display === 'none') {
+          el.style.display = 'block';
+        }
+      });
+      observer.observe(hostDoc.body || document.body, { childList: true, subtree: true });
+    } catch (_) {}
   }
 
   // Initialize immediately if DOM is ready, otherwise wait

--- a/public/styles.css
+++ b/public/styles.css
@@ -277,11 +277,13 @@ body {
   }
 
   .about-section {
-    padding: 80px 0;
+    padding: 60px 0;
+    min-height: 400px;
   }
 
   .about-title {
     font-size: 48px;
+    line-height: 48px;
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -307,16 +307,19 @@ body {
   }
 
   .about-section {
-    padding: 60px 0;
+    padding: 50px 0;
+    min-height: 350px;
   }
 
   .about-title {
-    font-size: 40px;
+    font-size: 42px;
+    line-height: 42px;
     letter-spacing: -1.2px;
   }
 
   .about-subtitle {
     font-size: 16px;
+    line-height: 26px;
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -67,6 +67,7 @@ body {
   font-size: 15px;
   font-weight: 400;
   transition: color 0.2s ease;
+  cursor: pointer;
 }
 
 .nav-link:hover {

--- a/public/styles.css
+++ b/public/styles.css
@@ -386,17 +386,22 @@ body {
 
   .about-section {
     padding: 40px 0;
+    min-height: 300px;
+  }
+
+  .about-container {
+    padding: 0 16px;
   }
 
   .about-title {
     font-size: 32px;
-    line-height: 1.1;
+    line-height: 36px;
     letter-spacing: -1px;
   }
 
   .about-subtitle {
     font-size: 15px;
-    line-height: 1.6;
+    line-height: 24px;
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -142,6 +142,17 @@ body {
   max-width: 590px;
 }
 
+.hero-subtitle-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.hero-subtitle-link:hover,
+.hero-subtitle-link:focus {
+  text-decoration: underline;
+}
+
 .get-started-button {
   display: flex;
   align-items: center;

--- a/public/styles.css
+++ b/public/styles.css
@@ -136,10 +136,10 @@ body {
 .hero-subtitle {
   font-size: 19px;
   font-weight: 400;
-  line-height: 1.5;
+  line-height: 28px;
   color: var(--text-secondary);
-  margin-bottom: 40px;
-  max-width: 306px;
+  margin: 0 auto 40px;
+  max-width: 590px;
 }
 
 .get-started-button {

--- a/public/styles.css
+++ b/public/styles.css
@@ -143,17 +143,6 @@ body {
   max-width: 590px;
 }
 
-.hero-subtitle-link {
-  color: inherit;
-  text-decoration: none;
-  transition: color 0.2s ease;
-}
-
-.hero-subtitle-link:hover,
-.hero-subtitle-link:focus {
-  text-decoration: underline;
-}
-
 .get-started-button {
   display: flex;
   align-items: center;

--- a/public/styles.css
+++ b/public/styles.css
@@ -215,38 +215,50 @@ body {
   align-items: center;
   justify-content: center;
   min-height: 498px;
+  width: 100%;
 }
 
 .about-container {
-  max-width: 1200px;
+  width: 100%;
+  max-width: 1920px;
   padding: 0 24px;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.about-content {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  text-align: center;
+  width: 100%;
 }
 
 .about-title {
   font-family: 'Instrument Sans', sans-serif;
-  font-size: 48px;
+  font-size: 54px;
   font-weight: 400;
-  line-height: 48px;
+  line-height: 54px;
   letter-spacing: -1.6px;
   color: #000;
   margin-bottom: 32px;
   max-width: 811px;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
+  text-align: center;
 }
 
 .about-subtitle {
   font-family: 'Inter', sans-serif;
   font-size: 17px;
   font-weight: 400;
-  line-height: 1.65;
+  line-height: 28px;
   letter-spacing: 0.36px;
   color: #5d5d5d;
-  max-width: 561px;
-  margin: 0 auto;
+  max-width: 590px;
+  width: 100%;
+  text-align: center;
+  margin: 0;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Purpose

The user requested to embed a specific website link (https://i5zphws.spread.name/) in the Properties navigation and fix an issue where the visual change editing option was not showing while editing the website. The changes aim to make the Properties link functional and ensure the visual editor toolbar is always accessible for content editing.

## Code changes

- **Navigation updates**: Updated Properties nav link across all HTML files (index.html, about.html, contact.html) to point to `https://i5zphws.spread.name/` with proper external link attributes (`target="_blank"` and `rel="noopener noreferrer"`)
- **Hero section layout improvements**: Enhanced responsive design for hero subtitle with proper centering, max-width of 590px, and improved line-height for better readability
- **About section restructuring**: Refactored about section HTML structure with new container/content wrapper for better layout control and responsive behavior
- **Visual editor toolbar fixes**: 
  - Enhanced edit mode detection to include more editor flags (`builder.preview`, `builder.mode`, `preview`)
  - Improved iframe detection logic to ensure toolbar shows in all editing contexts
  - Added persistent toolbar visibility with better mutation observer handling
  - Expanded regex patterns to catch more editor/preview scenarios
- **CSS responsive improvements**: Updated breakpoints and spacing for better mobile/tablet experience across hero and about sectionsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/30b7c8010c33439a86cb0735e54265c2/mystic-field)

👀 [Preview Link](https://30b7c8010c33439a86cb0735e54265c2-mystic-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>30b7c8010c33439a86cb0735e54265c2</projectId>-->
<!--<branchName>mystic-field</branchName>-->